### PR TITLE
Fix milestone issue not triggering workflow

### DIFF
--- a/.github/workflows/create-update-iteration-plan.yml
+++ b/.github/workflows/create-update-iteration-plan.yml
@@ -3,6 +3,8 @@ name: Create or Update Iteration Plan
 on:
   milestone:
     types: [created, closed, edited, opened]
+  issues:
+    types: [milestoned, edited, opened, closed]
 
 jobs:
   create-update-issue:

--- a/.github/workflows/github.js
+++ b/.github/workflows/github.js
@@ -39,4 +39,17 @@ async function getOrCreateIssue(milestone) {
   }
 }
 
-module.exports = { getOrCreateIssue };
+async function handleMilestoneEvent(event) {
+  const { action, issue, changes } = event;
+
+  if (action === 'milestoned') {
+    const milestoneBefore = issue.milestone;
+    const milestoneAfter = changes.milestone.after;
+
+    console.log(`Milestone changed from ${milestoneBefore.title} to ${milestoneAfter.title}`);
+
+    await getOrCreateIssue(milestoneAfter);
+  }
+}
+
+module.exports = { getOrCreateIssue, handleMilestoneEvent };


### PR DESCRIPTION
Add support for triggering workflow on issue milestone association.

* Modify `.github/workflows/create-update-iteration-plan.yml` to trigger on `issues` events with types `milestoned`, `edited`, `opened`, and `closed`.
* Add `handleMilestoneEvent` function in `.github/workflows/github.js` to handle `milestoned` event for issues.
* Record milestone before and after the change in `.github/workflows/github.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/askman-dev/askman-chrome-extension/tree/crazygo/add-milestone-issue-action?shareId=188b61dc-be50-4f30-9496-7862e760163d).