### PR TITLE
Add workflow to create or update iteration plan

### DIFF
--- a/.github/workflows/create-update-iteration-plan.yml
+++ b/.github/workflows/create-update-iteration-plan.yml
@@ -22,7 +22,17 @@ jobs:
       - name: Install dependencies
         run: npm install --prefix .github/workflows
 
+      - name: List Open Milestones
+        run: node -e "import { listOpenMilestones } from './github.js'; listOpenMilestones();"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create or Update Issue
-        run: node .github/workflows/github.js
+        run: node -e "import { getOrCreateIssue } from './github.js'; getOrCreateIssue();"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Iteration Plan
+        run: node -e "import { updateIterationPlan } from './github.js'; updateIterationPlan();"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add functionality to create or update issues related to milestone changes.

* **.github/workflows/github.js**
  - Add `listOpenMilestones` function to fetch and filter milestones.
  - Add `updateIterationPlan` function to update the issue's content with a list of issue links.
  - Modify `getOrCreateIssue` function to use `listOpenMilestones` and call `updateIterationPlan`.

* **.github/workflows/create-update-iteration-plan.yml**
  - Add a step to call `listOpenMilestones`.
  - Modify the step to call `getOrCreateIssue`.
  - Add a step to call `updateIterationPlan`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/askman-dev/askman-chrome-extension?shareId=a5bb4de7-651c-48e6-95c2-2f013f586708).