### PR TITLE
chore(docs): update documentation link in external configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "askman-chrome-extension",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Askman is an open-source browser extension that connects AI to web pages",
   "license": "GPL-3.0-only",
   "repository": {

--- a/src/assets/conf/external-links.toml
+++ b/src/assets/conf/external-links.toml
@@ -3,7 +3,7 @@
 
 [docs]
 # Documentation links
-home = "https://docs.qq.com/aio/DWUxocmZJV05GQXF5?p=PaTh0e2q3XbD8s7W4xJGnb#wXyP39ceAltKZiZ02AZpR0"
+home = "https://hfb0nkdpx8.feishu.cn/wiki/BElIwDoXvibmyvkphGucooNAnjg"
 issues = "https://github.com/askman-dev/askman-chrome-extension/issues"
 discussions = "https://github.com/askman-dev/askman-chrome-extension/discussions"
 


### PR DESCRIPTION
This pull request includes a version update and a change to the documentation links.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.0.13` to `0.0.14`.

Documentation links update:

* [`src/assets/conf/external-links.toml`](diffhunk://#diff-fd1554b8f3f4b62a9ccd762d4fbc9bc409ddb315a4ceb19a2c61e217a887d948L6-R6): Updated the home documentation link to a new URL.